### PR TITLE
Support alternative keyType (name) for teachers when querying timetables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = ['requests']
 
 setup(
     name='webuntis',
-    version='0.1.23',
+    version='0.1.24',
     author=u'Markus Unterwaditzer, August Hörandl',
     author_email='markus@unterwaditzer.net, august.hoerandl@gmx.at',
     packages=find_packages(),

--- a/webuntis/session.py
+++ b/webuntis/session.py
@@ -228,7 +228,7 @@ class ResultWrapperMixin(object):
         return objects.PeriodList, 'getTimetable', parameters
 
     @result_wrapper
-    def timetable_extended(self, start, end, **type_and_id):
+    def timetable_extended(self, start, end, key_type="id", teacher_fields=["id"], **type_and_id):
         """Get the timetable for a specific school class and time period.
 
         Like timetable, but includes more info.
@@ -257,7 +257,7 @@ class ResultWrapperMixin(object):
         if element_type not in element_type_table:
             raise invalid_type_error
 
-        return self._timetable_extended_raw(end, start, element_id, element_type_table[element_type])
+        return self._timetable_extended_raw(end, start, element_id, element_type_table[element_type], key_type, teacher_fields)
 
     @result_wrapper
     def my_timetable(self, end, start):
@@ -269,14 +269,16 @@ class ResultWrapperMixin(object):
                                             self.login_result['personId'], self.login_result['personType'])
 
 
-    def _timetable_extended_raw(self, end, start, element_id, element_type_num):
-
+    def _timetable_extended_raw(self, end, start, element_id, element_type_num, key_type="id", teacher_fields=["id"]):
+        element = {
+            "id" : int(element_id) if key_type == "id" else element_id,
+            "type": element_type_num,
+            "keyType": key_type
+        }
         options = self._create_date_param(end,
                                           start,
-                                          element={
-                                              "id": int(element_id),
-                                              "type": element_type_num,
-                                          },
+                                          element=element,
+                                          teacherFields=teacher_fields,
                                           onlyBaseTimetable=False,
                                           showBooking=True,
                                           showInfo=True,


### PR DESCRIPTION
- Allows to query the timetable_extended by providing the initials of a teacher (no need to explicitly query the teacher beforehand)
- Specifically handy when teachers have multiple given names which makes it hard to find them by name

**Example call: (see # New Approach)**
```python
with Session(
        server="https://untis.hogwarts.edu",
        username=username,
        password=password,
        school="Hogwarts",
        useragent='carpoolparty - thabok@something.com'
    ).login() as session:

    # Old Approach: querying timetable for Albus Dumbledore - I need to know all given names :(
    albus_dumbledore = session.get_teacher(surname='Dumbledore', fore_name='Albus Percival Wulfric Brian')
    timetable = session.timetable_extended(start=20250217,
                                           end=20250227,
                                           teacher=albus_dumbledore)

    # New Approach: querying timetable for Albus Dumbledore - I only need to know his short-hand / initials :)
    timetable = session.timetable_extended(start=20250217,
                                           end=20250227,
                                           key_type="name",
                                           teacher_fields=["id", "name", "externalkey"],
                                           teacher='Dd')
```

I opted for a conservative approach with minimal refactorign impact: no changes in existing behavior.