### PR TITLE
Fix regex for valid hostname check

### DIFF
--- a/webuntis/utils/userinput.py
+++ b/webuntis/utils/userinput.py
@@ -23,7 +23,7 @@ def server(url):
         # urlparse failed
         raise ValueError('Not a valid URL or hostname')
 
-    if not re.match(r'^[a-zA-Z0-9.:-_]+$', urlobj.netloc):
+    if not re.match(r'^[a-zA-Z0-9.:\-_]+$', urlobj.netloc):
         # That's not even a valid hostname
         raise ValueError('Not a valid hostname')
 


### PR DESCRIPTION
Updated hostname validation to allow dashes (-) because school URLs are now used, and they often include hyphens.

More information for the WebUntis URL changes: https://help.untis.at/hc/en-150/articles/22597731127708-New-web-addresses-for-WebUntis